### PR TITLE
Add the junit library to project properties

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -61,7 +61,6 @@ javadoc.windowtitle=
 javafx.application.implementation.version=1.0
 javafx.binarycss=false
 javafx.classpath.extension=\
-    ${java.home}/lib/jfxrt.jar:\
     ${java.home}/lib/javaws.jar:\
     ${java.home}/lib/deploy.jar:\
     ${java.home}/lib/plugin.jar

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -44,7 +44,8 @@ javac.source=1.7
 javac.target=1.7
 javac.test.classpath=\
     ${javac.classpath}:\
-    ${build.classes.dir}
+    ${build.classes.dir}:\
+    ${libs.junit_4.classpath}
 javac.test.processorpath=\
     ${javac.test.classpath}
 javadoc.additionalparam=


### PR DESCRIPTION
I didn't intentionally delete this line:  ${java.home}/lib/jfxrt.jar:\

I can't seem to make changes to project.properties without deleting this line. I don't think it will have any impact but I don't know.

You will not be able to run the tests without the junit library in project properties.
